### PR TITLE
chore: sync plugin.json version to latest tag v0.3.2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-steam",
-  "version": "0.2.1",
+  "version": "0.3.2",
   "author": "GoCodeAlone",
   "description": "Steam platform integration: auth, achievements, leaderboards, rich presence, friends, and Workshop",
   "type": "external",


### PR DESCRIPTION
Sync the `version` field in `plugin.json` to match the latest git release tag, eliminating drift between the published tag and the manifest the registry/consumers read.

**Change:** `version` field updated to match latest tag.

This is a pure metadata sync — no code changes.