### PR TITLE
fix(release): remove invalid after: hooks section from goreleaser config (v0.3.4)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,14 +2,8 @@ version: 2
 
 before:
   hooks:
-    - "cp plugin.json plugin.json.orig"
     - "sed -i.bak 's/\"version\": \".*\"/\"version\": \"{{ .Version }}\"/' plugin.json && rm -f plugin.json.bak"
     - "sed -i.bak 's|releases/download/v[^/]*/|releases/download/v{{ .Version }}/|g' plugin.json && rm -f plugin.json.bak"
-    - "go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.20.1 plugin validate --file plugin.json --strict-contracts"
-
-after:
-  hooks:
-    - "mv plugin.json.orig plugin.json"
 
 builds:
   - id: workflow-plugin-steam


### PR DESCRIPTION
## Summary
- GoReleaser v2 does not support a top-level `after:` hooks block
- Removed the after: section along with the now-unnecessary cp and stale wfctl@v0.20.1 validate hook
- validate-contract is already handled by release.yml

## Root cause
Run 26373050113 failed: `yaml: unmarshal errors: line 10: field after not found in type config.Project`