### PR TITLE
fix(release): publish before registry sync + non-fatal registry step (v0.3.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,15 @@ jobs:
             exit 0
           fi
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
+      - name: Publish GitHub release
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
+
       - name: Update registry manifest
         if: success()
+        continue-on-error: true
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           PLUGIN_NAME="${GITHUB_REPOSITORY##*/}"


### PR DESCRIPTION
## Summary
- Registry update step was failing due to empty REGISTRY_PAT secret, blocking the Publish step
- Moved publish step BEFORE registry update so it always runs if goreleaser succeeds
- Added continue-on-error: true to registry update step

## Root cause
Run 26374510806: registry push failed with "Invalid username or token" (REGISTRY_PAT empty), the release stayed as draft v0.3.4