### PR TITLE
ci: canonical registry notify (fix dead dispatch + drop manifest-overwrite)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,73 +62,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
 
-      - name: Update registry manifest
-        if: success()
-        continue-on-error: true
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          PLUGIN_NAME="${GITHUB_REPOSITORY##*/}"
-          REGISTRY_NAME="${PLUGIN_NAME#workflow-plugin-}"
-          REGISTRY_NAME="${REGISTRY_NAME#workflow-}"
-          BASE_URL="https://github.com/GoCodeAlone/${PLUGIN_NAME}/releases/download/v${VERSION}/${PLUGIN_NAME}"
-
-          git clone "https://x-access-token:${REGISTRY_PAT}@github.com/GoCodeAlone/workflow-registry.git" /tmp/workflow-registry
-          cd /tmp/workflow-registry
-
-          MANIFEST="plugins/${REGISTRY_NAME}/manifest.json"
-          if [[ ! -f "${MANIFEST}" ]]; then
-            echo "No manifest found at ${MANIFEST}, skipping registry update."
-            exit 0
-          fi
-
-          jq --arg v "${VERSION}" \
-             --arg base "${BASE_URL}" \
-             '.version = $v |
-              .downloads = [
-                {os: "linux",  arch: "amd64", url: ($base + "-linux-amd64.tar.gz")},
-                {os: "linux",  arch: "arm64", url: ($base + "-linux-arm64.tar.gz")},
-                {os: "darwin", arch: "amd64", url: ($base + "-darwin-amd64.tar.gz")},
-                {os: "darwin", arch: "arm64", url: ($base + "-darwin-arm64.tar.gz")}
-              ]' "${MANIFEST}" > tmp.json && mv tmp.json "${MANIFEST}"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          BRANCH="auto/sync-${PLUGIN_NAME}-v${VERSION}"
-          git checkout -b "${BRANCH}"
-          git add "plugins/${REGISTRY_NAME}/manifest.json"
-          git commit -m "sync: ${PLUGIN_NAME} v${VERSION}"
-          git push "https://x-access-token:${REGISTRY_PAT}@github.com/GoCodeAlone/workflow-registry.git" "${BRANCH}"
-
-          gh pr create \
-            --repo GoCodeAlone/workflow-registry \
-            --head "${BRANCH}" \
-            --base main \
-            --title "sync: ${PLUGIN_NAME} v${VERSION}" \
-            --body "Auto-sync \`${PLUGIN_NAME}\` manifest to v${VERSION}" \
-            --label "auto-sync" || true
-        env:
-          REGISTRY_PAT: ${{ secrets.REGISTRY_PAT }}
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-
-  notify-registry:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [release]
+  notify-workflow-registry:
+    name: Notify workflow-registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: release
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-steam'
     steps:
-      - name: Notify workflow-registry
-        if: env.GH_TOKEN != ''
-        uses: peter-evans/repository-dispatch@v3
+      - name: Trigger registry manifest sync
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
         with:
-          token: ${{ secrets.REGISTRY_PAT }}
+          token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry
           event-type: plugin-release
-          client-payload: >-
-            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
-        env:
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-        continue-on-error: true
-      - name: Publish GitHub release
-        if: ${{ success() }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
+          client-payload: |-
+            {"plugin": "steam", "tag": "${{ github.ref_name }}"}


### PR DESCRIPTION
Replaces the broken two-pronged registry notification with the fleet-canonical pattern.

**Removed:**
- Direct manifest-write step that cloned workflow-registry, patched `plugins/steam/manifest.json` via `REGISTRY_PAT` — over-privileged and races with registry-side tooling
- `notify-registry` job using `peter-evans/repository-dispatch@v3` with wrong token (`REGISTRY_PAT`), wrong plugin name (`github.repository` instead of bare `steam`), and no pre-release/deletion guards

**Added:**
- `notify-workflow-registry` job matching fleet standard: pinned `@v4` digest, `secrets.repo_dispatch_token`, bare name `"steam"`, correct guards (`!deleted`, no pre-release hyphen, repo check)